### PR TITLE
Was required to avoid a missing prototype warning.

### DIFF
--- a/c_src/lz4hc.c
+++ b/c_src/lz4hc.c
@@ -454,6 +454,11 @@ inline static int LZ4_encodeSequence(const BYTE** ip, BYTE** op, const BYTE** an
 //****************************
 
 int LZ4_compressHCCtx(LZ4HC_Data_Structure* ctx,
+                 const char* source,
+                 char* dest,
+                 int isize);
+
+int LZ4_compressHCCtx(LZ4HC_Data_Structure* ctx,
 				 const char* source, 
 				 char* dest,
 				 int isize)


### PR DESCRIPTION
Found when compiling with warnings as errors.
