### PR TITLE
Add no_native flag to not crash the HiPE compiler

### DIFF
--- a/src/lz4.erl
+++ b/src/lz4.erl
@@ -3,6 +3,7 @@
 -export([compress/1, compress/2, uncompress/2,
     pack/1, pack/2, unpack/1]).
 
+-compile(no_native).
 -on_load(init/0).
 
 -type option() :: high.


### PR DESCRIPTION
Add `no_native` flag to force NOT compile with native. This is a bit of a hack, ideally, the HiPE compiler wouldn't crash and would just skip modules with `on_load` directives.

Here's a similar PR for OTP:
https://github.com/erlang/otp/pull/1390

```erlang
crash reason: {badmatch,
    {'EXIT',
        {{hipe_beam_to_icode,1148,{'trans_fun/2',on_load}},
         [{hipe_beam_to_icode,trans_fun,2,
              [{file,"hipe_beam_to_icode.erl"},{line,1148}]},
          {hipe_beam_to_icode,trans_fun,2,
              [{file,"hipe_beam_to_icode.erl"},{line,278}]},
          {hipe_beam_to_icode,trans_mfa_code,5,
              [{file,"hipe_beam_to_icode.erl"},{line,149}]},
          {hipe_beam_to_icode,trans_beam_function_chunk,2,
              [{file,"hipe_beam_to_icode.erl"},{line,134}]},
          {hipe_beam_to_icode,'-module/2-lc$^1/1-1-',2,
              [{file,"hipe_beam_to_icode.erl"},{line,130}]},
          {hipe,get_beam_icode,4,[{file,"hipe.erl"},{line,600}]},
          {hipe,'-run_compiler_1/4-fun-0-',5,
              [{file,"hipe.erl"},{line,675}]}]}}}
```