### PR TITLE
Fix artifacts detection on win32

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, [{i, "src"},
+            debug_info,
             warnings_as_errors,
             {w, all},
             warn_export_all]}.
@@ -8,10 +9,21 @@
 
 {eunit_opts, [{report,{eunit_surefire,[{dir,"."}]}}]}.
 
+%% The extension of the artifact is modified in rebar.config.script for win32
+{artifacts, ["priv/lz4.so"]}.
+
 %% Compile nif using port compiler plugin
 {plugins, [pc]}.
-{artifacts, ["priv/lz4.so"]}.
-{port_specs, [{ "priv/lz4.so", ["c_src/*.c"] }]}.
-{provider_hooks,
-    [ {post, [ {compile, {pc, compile}},
-               {clean, {pc, clean}} ] }] }.
+
+{provider_hooks, [
+    {pre, [
+        {compile, {pc, compile}},
+        {clean,   {pc, clean}}
+    ]}
+]}.
+
+{port_specs, [
+    {"priv/lz4.so", [
+        "c_src/*.c"
+    ]}
+]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,20 @@
+%% -*- erlang -*-
+
+IsWindows = case os:type() of {win32, _} -> true; {_, _} -> false end,
+
+MaybeSwitchToDll = fun(File) ->
+                        case IsWindows of
+                            false ->
+                                File;
+                            true ->
+                                case filename:extension(File) of
+                                    ".so"  -> filename:rootname(File, ".so") ++ ".dll";
+                                    []     -> File ++ ".exe";
+                                    _Other -> File
+                                end
+                            end
+                    end,
+
+{artifacts, Artifacts0} = lists:keyfind(artifacts, 1, CONFIG),
+Artifacts1 = [MaybeSwitchToDll(F) || F <- Artifacts0],
+lists:keyreplace(artifacts, 1, CONFIG, {artifacts, Artifacts1}).


### PR DESCRIPTION
`rebar3` would always look for `.so` instead of `.dll` files.