### PR TITLE
Include description to avoid packaging failures

### DIFF
--- a/src/lz4.app.src
+++ b/src/lz4.app.src
@@ -1,6 +1,6 @@
 {application, lz4,
  [
-  {description, ""},
+  {description, "LZ4 bindings for Erlang"},
   {vsn, "0.2.2"},
   {registered, []},
   {applications, [


### PR DESCRIPTION
I ran into an issue with building a release of a service which uses this library. rebar3 complained during the release build phase that the description string was empty for this application. This PR fixes that issue.